### PR TITLE
Fix auth email verification lookup and align docs/tests

### DIFF
--- a/backend/readme.md
+++ b/backend/readme.md
@@ -87,7 +87,7 @@ These endpoints allow users to interact with the Will Be There application:
 
 **Responses:**
 
-* **200 OK:** Signup successful!   A JSON response with user information and an authorization token is returned.
+* **201 Created:** Signup successful! A JSON response with user information and a success message is returned (email verification is required).
 * **400 Bad Request:**  Oops!  There's an error in your request.  Check the parameters and try again. ❗️
 
 **2. Login Endpoint (Let's Get RSVPing!)**
@@ -103,4 +103,4 @@ These endpoints allow users to interact with the Will Be There application:
 
 **Responses:**
 
-* **200 OK:** Login successful!  A JSON response with user information and an authorization token is returned.
+* **200 OK:** Login successful! A JSON response with JWT `access` and `refresh` tokens plus user information is returned.

--- a/backend/src/Auth/views.py
+++ b/backend/src/Auth/views.py
@@ -92,7 +92,7 @@ def Verify_account(request):
     email = request.data.get("email")
     verification_code = request.data.get("verification_code")
     try:
-        user = User.objects.get(username=email)
+        user = User.objects.get(email=email)
         user_profile = userProfile.objects.get(user=user)
         if user_profile.verification_code == verification_code:
             user_profile.is_verified = True
@@ -124,7 +124,7 @@ def resend_Verification_code(request):
     """resend verification code"""
     email = request.data.get("email")
     try:
-        user = User.objects.get(username=email)
+        user = User.objects.get(email=email)
         user_profile = userProfile.objects.get(user=user)
         code = verify_email(email)
         user_profile.verification_code = code

--- a/backend/tests/test_Auth.py
+++ b/backend/tests/test_Auth.py
@@ -26,7 +26,9 @@ class UserSignUpTestCase(APITestCase):
         """Test successful user signup"""
         response = self.client.post(self.signup_url, self.valid_signup_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertIn("token", response.json())
+        self.assertIn("access", response.json())
+        self.assertIn("refresh", response.json())
+        self.assertIn("user", response.json())
         self.assertIn("user", response.json())
 
         # Verify user was created in database
@@ -84,7 +86,9 @@ class UserLoginTestCase(APITestCase):
         login_data = {"email": "testuser@example.com", "password": "TestPass123!"}
         response = self.client.post(self.login_url, login_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("token", response.json())
+        self.assertIn("access", response.json())
+        self.assertIn("refresh", response.json())
+        self.assertIn("user", response.json())
 
     def test_login_unverified_email(self):
         """Test login fails with unverified email"""
@@ -144,6 +148,28 @@ class EmailVerificationTestCase(APITestCase):
         }
         response = self.client.post(self.verify_url, verify_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+    def test_verification_with_distinct_username_and_email(self):
+        """Test verification succeeds when username differs from email"""
+        distinct_user = User.objects.create_user(
+            username="different_username",
+            email="different@example.com",
+            password="TestPass123!",
+        )
+        userProfile.objects.create(
+            user=distinct_user,
+            phone_number="+1987654321",
+            is_verified=False,
+            verification_code="654321",
+        )
+
+        verify_data = {"email": "different@example.com", "verification_code": "654321"}
+        response = self.client.post(self.verify_url, verify_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        verified_profile = userProfile.objects.get(user=distinct_user)
+        self.assertTrue(verified_profile.is_verified)
 
     def test_verification_nonexistent_email(self):
         """Test verification with non-existent email"""

--- a/frontend/src/utils/local-data.ts
+++ b/frontend/src/utils/local-data.ts
@@ -64,13 +64,13 @@ export const whoWeAreData = [
 // Data for the testimonial section
 export const testmonialData = [
   {
-    desc: 'Will Be There has transformed the way we plan and manage events. It is intuitive, effecient, and has all the features we need to ensure our events are a success.',
+    desc: 'Will Be There has transformed the way we plan and manage events. It is intuitive, efficient, and has all the features we need to ensure our events are a success.',
     img: testmonialImage1,
     name: 'Sarah Johnson',
     occupation: 'Event manager, YM Capital',
   },
   {
-    desc: 'I love how easy it is to RSVP for events using Wil Be There. The process is seamless, and I always know exactly what to expect when attending an event.',
+    desc: 'I love how easy it is to RSVP for events using Will Be There. The process is seamless, and I always know exactly what to expect when attending an event.',
     img: testmonialImage2,
     name: 'John Yuri',
     occupation: 'Attendee',

--- a/project/docs/ISSUE_TASK_PROPOSALS.md
+++ b/project/docs/ISSUE_TASK_PROPOSALS.md
@@ -1,0 +1,40 @@
+# Issue Task Proposals
+
+## 1) Typo fix task
+**Task:** Correct misspelled copy in testimonial content (`"effecient"` -> `"efficient"` and `"Wil Be There"` -> `"Will Be There"`) in `frontend/src/utils/local-data.ts`.
+
+**Why:** These are user-visible spelling errors that reduce product polish.
+
+**Acceptance criteria:**
+- Text strings are corrected in the source file.
+- UI surfaces that consume this data show corrected text.
+
+## 2) Bug fix task
+**Task:** Fix email lookup logic in auth verification endpoints so users are fetched by `email` instead of `username` in `backend/src/Auth/views.py` (`Verify_account` and `resend_Verification_code`).
+
+**Why:** The current code reads `User.objects.get(username=email)`, which fails when a user's username differs from their email and can incorrectly return 404 for valid accounts.
+
+**Acceptance criteria:**
+- Both endpoints use `User.objects.get(email=email)` (or equivalent robust lookup).
+- Existing verification flows work for users whose username is not their email.
+- Add/adjust tests to cover the username != email case.
+
+## 3) Documentation discrepancy task
+**Task:** Align `backend/readme.md` auth endpoint responses with actual API behavior in `backend/src/Auth/views.py`.
+
+**Why:** The README states signup returns `200 OK` + token and login returns an "authorization token", while implementation returns `201` with message/user on signup and JWT `refresh`/`access` fields on login.
+
+**Acceptance criteria:**
+- Signup docs mention `201 Created` and correct response payload.
+- Login docs mention JWT `access`/`refresh` fields.
+- Any example payloads in README reflect current API output.
+
+## 4) Test improvement task
+**Task:** Improve login API tests in `backend/tests/test_Auth.py` to assert the real response contract (`access`, `refresh`, and `user`) instead of `token`, and add a regression test for verification-by-email lookup.
+
+**Why:** Current test expectations are stale and can hide API regressions.
+
+**Acceptance criteria:**
+- `test_successful_login` validates `access` and `refresh` keys.
+- A new test verifies account verification succeeds when `username != email`.
+- Test suite passes after updates.


### PR DESCRIPTION
### Motivation
- Ensure account verification works when a user's `username` differs from their `email` by fixing the lookup logic in the verification endpoints.
- Improve product polish by fixing visible copy typos in testimonial strings.
- Align backend documentation with the API's real responses so clients and tests reflect current behavior.

### Description
- Update `backend/src/Auth/views.py` to look up users by `email` instead of `username` in `Verify_account` and `resend_Verification_code` to avoid false 404s for users whose `username` differs from their email.
- Correct typographical errors in `frontend/src/utils/local-data.ts` (`"effecient"` → `"efficient"`, `"Wil Be There"` → `"Will Be There"`).
- Update `backend/readme.md` to document `201 Created` for signup and that login returns JWT `access` and `refresh` tokens along with user info.
- Adjust `backend/tests/test_Auth.py` to assert `access`, `refresh`, and `user` keys for successful auth responses and add a regression test covering verification when `username != email`.

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff issues, which passed.
- Attempted to run the auth test file with `cd backend && python -m pytest tests/test_Auth.py -q`, but test collection failed with `ModuleNotFoundError: No module named 'django'` because Django is not installed in this environment (test run aborted).
- Attempted a Playwright-based frontend smoke check to `http://127.0.0.1:5173`, which failed with `ERR_EMPTY_RESPONSE` because no frontend server was reachable in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1db3cafc83248c9afaacd984f517)